### PR TITLE
Update mcp2515 - Lectura y escritura con freertos

### DIFF
--- a/MCP2515_Example/source/Includes/mcp2515.h
+++ b/MCP2515_Example/source/Includes/mcp2515.h
@@ -34,7 +34,7 @@
  * Si definimos USE_FREERTOS 1 entonces estamos utilizando el sistema en tiempo real de freertos
  * Si definimos USE_FREERTOS 0 entonces estamos utilizando el sistema de baremetal.
  */
-#define USE_FREERTOS 0
+#define USE_FREERTOS 1
 
 /*
  * @brief Speed 8M.


### PR DESCRIPTION
Agregado: Ahora el programa funciona para elegir entre freertos o baremetal. Se debe seleccionar desde la libreria.

Fix: Se corrigio el problema que no dejaba utilizar freertos.